### PR TITLE
Improved 10 minute CI run and switched to local_vars_small.yml

### DIFF
--- a/.github/workflows/10min-iiab-test-install.yml
+++ b/.github/workflows/10min-iiab-test-install.yml
@@ -1,46 +1,14 @@
 name: '"10 min" IIAB on Ubuntu 24.04 on x86-64'
-# run-name: ${{ github.actor }} is testing out GitHub Actions 🚀
 
-# https://michaelcurrin.github.io/dev-cheatsheets/cheatsheets/ci-cd/github-actions/triggers.html
 on: [push, pull_request, workflow_dispatch]
-
-# on:
-#   push:
-#
-#   pull_request:
-#
-#   # Allows you to run this workflow manually from the Actions tab
-#   workflow_dispatch:
-#
-#   # Set your workflow to run every day of the week from Monday to Friday at 6:00 UTC
-#   schedule:
-#     - cron: "0 6 * * 1-5"
 
 jobs:
   test-install:
     runs-on: ubuntu-24.04
     steps:
-      - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
-      - run: echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
-      #- name: Dump GitHub context (typically almost 500 lines)
-      #  env:
-      #    GITHUB_CONTEXT: ${{ toJSON(github) }}
-      #  run: echo "$GITHUB_CONTEXT"
       - name: Check out repository code
         uses: actions/checkout@v4
       - run: echo "🍏 This job's status is ${{ job.status }}."
-      - name: GitHub Actions "runner" environment
-        run: |
-          uname -a    # uname -srm
-          whoami      # Typically 'runner' instead of 'root'
-          pwd         # /home/runner/work/iiab/iiab == $GITHUB_WORKSPACE == ${{ github.workspace }}
-          # ls
-          # ls $GITHUB_WORKSPACE
-          # ls ${{ github.workspace }}
-          # ls -la /opt    # az, containerd, google, hostedtoolcache, microsoft, mssql-tools, pipx, pipx_bin, post-generation, runner, vsts
-          # apt update
-          # apt dist-upgrade -y
-          # apt autoremove -y
       - name: Set up /opt/iiab/iiab
         run: |
           mkdir /opt/iiab
@@ -49,8 +17,7 @@ jobs:
       - name: Set up /etc/iiab/local_vars.yml
         run: |
           sudo mkdir /etc/iiab
-          # touch /etc/iiab/local_vars.yml
-          sudo cp /opt/iiab/iiab/vars/local_vars_none.yml /etc/iiab/local_vars.yml
+          sudo cp /opt/iiab/iiab/vars/local_vars_small.yml /etc/iiab/local_vars.yml
       - run: sudo /opt/iiab/iiab/scripts/ansible
       - run: sudo ./iiab-install
         working-directory: /opt/iiab/iiab

--- a/.github/workflows/10min-iiab-test-install.yml
+++ b/.github/workflows/10min-iiab-test-install.yml
@@ -8,12 +8,11 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
-      - run: echo "🍏 This job's status is ${{ job.status }}."
       - name: Set up /opt/iiab/iiab
         run: |
           mkdir /opt/iiab
           mv $GITHUB_WORKSPACE /opt/iiab
-          mkdir $GITHUB_WORKSPACE    # OR SUBSEQUENT STEPS WILL FAIL ('working-directory: /opt/iiab/iiab' hacks NOT worth it!)
+          mkdir $GITHUB_WORKSPACE
       - name: Set up /etc/iiab/local_vars.yml
         run: |
           sudo mkdir /etc/iiab

--- a/.github/workflows/10min-iiab-test-install.yml
+++ b/.github/workflows/10min-iiab-test-install.yml
@@ -21,4 +21,4 @@ jobs:
       - run: sudo ./iiab-install
         working-directory: /opt/iiab/iiab
       - run: iiab-summary
-      - run: diff /etc/iiab/iiab_state.yml /opt/iiab/tests.unused/expected_state_small.yml
+      - run: diff /etc/iiab/iiab_state.yml /opt/iiab/iiab/tests.unused/expected_state_small.yml

--- a/.github/workflows/10min-iiab-test-install.yml
+++ b/.github/workflows/10min-iiab-test-install.yml
@@ -21,4 +21,4 @@ jobs:
       - run: sudo ./iiab-install
         working-directory: /opt/iiab/iiab
       - run: iiab-summary
-      - run: cat /etc/iiab/iiab_state.yml
+      - run: diff /etc/iiab/iiab_state.yml /opt/iiab/tests.unused/expected_state_small.yml

--- a/.github/workflows/10min-iiab-test-install.yml
+++ b/.github/workflows/10min-iiab-test-install.yml
@@ -21,4 +21,6 @@ jobs:
       - run: sudo ./iiab-install
         working-directory: /opt/iiab/iiab
       - run: iiab-summary
+      - run: cat /etc/iiab/iiab_state.yml
+      - run: cat /opt/iiab/iiab/tests.unused/expected_state_small.yml
       - run: diff /etc/iiab/iiab_state.yml /opt/iiab/iiab/tests.unused/expected_state_small.yml

--- a/.github/workflows/10min-iiab-test-install.yml
+++ b/.github/workflows/10min-iiab-test-install.yml
@@ -21,6 +21,4 @@ jobs:
       - run: sudo ./iiab-install
         working-directory: /opt/iiab/iiab
       - run: iiab-summary
-      - run: cat /etc/iiab/iiab_state.yml
-      - run: cat /opt/iiab/iiab/tests.unused/expected_state_small.yml
       - run: diff /etc/iiab/iiab_state.yml /opt/iiab/iiab/tests.unused/expected_state_small.yml

--- a/tests.unused/expected_state_small.yml
+++ b/tests.unused/expected_state_small.yml
@@ -1,5 +1,6 @@
 # DO *NOT* MANUALLY EDIT THIS, THANKS!
 # IIAB does NOT currently support uninstalling apps/services.
+
 sshd_installed: True
 tailscale_installed: True
 remoteit_installed: True

--- a/tests.unused/expected_state_small.yml
+++ b/tests.unused/expected_state_small.yml
@@ -1,0 +1,20 @@
+# DO *NOT* MANUALLY EDIT THIS, THANKS!
+# IIAB does NOT currently support uninstalling apps/services.
+sshd_installed: True
+tailscale_installed: True
+remoteit_installed: True
+iiab_admin_installed: True
+network_installed: True
+nginx_installed: True
+www_base_installed: True
+pylibs_installed: True
+usb_lib_installed: True
+www_options_installed: True
+kolibri_installed: True
+kiwix_installed: True
+osm_vector_maps_installed: True
+awstats_installed: True
+mysql_installed: True
+matomo_installed: True
+captiveportal_installed: True
+calibreweb_installed: True


### PR DESCRIPTION
### Description of changes proposed in this pull request:
As requested by Adam Holt, I cleaned up the 10 minute CI run. Here is the gist of what I did:

- Removed commented out lines, run statements that just reported status and unncessary comments
- Switched from local_vars_none.yml to local_vars_small.yml
- Added a new file: tests.unused/expected_state_small.yml which matches the content of /etc/iiab/iiab_state.yml when the install is successful
- Added a run statement that compares the /etc/iiab/iiab_state.yml and tests.unused/expected_state_small.yml with diff, just to give the CI run a validation at the end

### Smoke-tested on which OS or OS's:
The 10 minute CI run uses Ubuntu